### PR TITLE
Destroy organisation method

### DIFF
--- a/graphql-database-manager-core/src/main/java/com/fleetpin/graphql/database/manager/Database.java
+++ b/graphql-database-manager-core/src/main/java/com/fleetpin/graphql/database/manager/Database.java
@@ -176,6 +176,10 @@ public class Database {
 		});
 	}
 
+	public CompletableFuture<Boolean> destroyOrganisation(final String organisationId) {
+		return driver.destroyOrganisation(organisationId);
+	}
+
 	/**
 	 * Will only pass if the entity revision matches what is currently in the database
 	 * @param <T> database entity type to update

--- a/graphql-database-manager-core/src/main/java/com/fleetpin/graphql/database/manager/DatabaseDriver.java
+++ b/graphql-database-manager-core/src/main/java/com/fleetpin/graphql/database/manager/DatabaseDriver.java
@@ -43,6 +43,8 @@ public abstract class DatabaseDriver {
 
     public abstract String newId();
 
+    public abstract CompletableFuture<Boolean> destroyOrganisation(final String organisationId);
+
     protected <T extends Table> String getSourceOrganistaionId(final T entity) {
         return entity.getSourceOrganistaionId();
     }


### PR DESCRIPTION
There was no feasible way to go and completely destroy all data
associated to an organisation. This new method allows this to happen and
it comes with a DynamoDb implementation.